### PR TITLE
Parse return promise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-- '0.12'
-- '0.11'
-- '0.10'
-- iojs
+- '4'
+- '6'
+- 'iojs'
 deploy:
   provider: npm
   email: marcello.desales@gmail.com

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,14 @@ var XML2JS_OPTS = {
  * @param {object} opt Is the option with the filePath or xmlContent and the optional format.
  * @return {object} The pom object along with the timers.
  */
-module.exports.parse = function(opt, callback) {
+module.exports.parse = function(opt, cb) {
+  var resolve, reject;
+
+  const callback = (cb)? cb : function(){/*noop*/};
+  const promise = new Promise(function(res, rej) {
+    resolve = res; reject = rej;
+  });
+
   if (!opt) {
     throw new Error("You must provide options: opt.filePath and any other option of " +
       "https://github.com/Leonidas-from-XIV/node-xml2js#options");
@@ -37,25 +44,31 @@ module.exports.parse = function(opt, callback) {
       return xmlContent;
 
     }).then(_parseWithXml2js).then(function(result) {
+      resolve(result);
       callback(null, result);
 
     }).catch(function(e) {
+      reject(e);
       callback(e, null);
  
     }).error(function (e) {
+      reject(e);
       callback(e, null);
     });
 
   } else {
     // parse the xml provided by the api client.
     _parseWithXml2js(opt.xmlContent).then(function(result) {
-      delete result.xmlContent;  
+      delete result.xmlContent;
+      resolve(result);
       callback(null, result);
 
     }).error(function (e) {
+      reject(e);
       callback(e);
     });
   }
+  return promise;
 
 };
 

--- a/test/promise.js
+++ b/test/promise.js
@@ -1,0 +1,63 @@
+var pomParser = require("../lib");
+var expect = require('chai').expect;
+var assert = require('assert');
+
+var POM_PATH = __dirname + "/fixture/pom.xml";
+var POM_PATH_BAD = __dirname + "/fixture/pom_badpath.xml";
+
+describe('parse.then - resolve on valid input', function() {
+  var pomResponse = null;
+  var pom = null;
+  var xml = null;
+  var parseErr = null;
+
+  before(function(done) {
+    pomParser.parse({filePath: POM_PATH})
+      .then(function(response) {
+        pomResponse = response;
+        pom = pomResponse.pomObject;
+        xml = pomResponse.pomXml;
+      }, function(err) {
+        parseErr = err;
+      })
+      .finally(function() {
+          expect(parseErr).to.be.null;
+          expect(pomResponse).to.be.an("object");
+          done();
+      });
+  });
+
+  it('resolves promise on good pom & path', function(done) {
+    expect(pomResponse.pomXml).to.be.an("string");
+    expect(pomResponse.pomObject).to.be.an("object");
+    done();
+  });
+});
+
+describe('parse.then - reject on bad input', function() {
+  var pomResponse = null;
+  var pom = null;
+  var xml = null;
+  var parseErr = null;
+
+  before(function(done) {
+    pomParser.parse({filePath: POM_PATH_BAD})
+      .then(function(response) {
+        pomResponse = response;
+        pom = pomResponse.pomObject;
+        xml = pomResponse.pomXml;
+      }, function(err) {
+        parseErr = err;
+      })
+      .finally(function() {
+        expect(parseErr).to.be.Error;
+        expect(pomResponse).to.be.null;
+        done();
+      });
+  });
+
+  it('rejects promise on invalid path', function(done) {
+    done();
+  });
+});
+


### PR DESCRIPTION
It's really nice to give users the option to use Promises over try/catch blocks in most cases.

The branch adds the ability to parse(opts).then() without breaking any existing functionality.

I've added test cases for resolve and a reject (on bad file url).