### PR TITLE
add test to verify error response for invalid xml

### DIFF
--- a/test/fixture/pom3.xml
+++ b/test/fixture/pom3.xml
@@ -1,0 +1,7 @@
+<project>
+  <!-- comment with a -- in it -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.mycompany.app</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1</version>
+</project>

--- a/test/invalid-xml-test.js
+++ b/test/invalid-xml-test.js
@@ -1,0 +1,25 @@
+var pomParser = require("../lib");
+var assert = require('assert');
+
+var POM_PATH = __dirname + "/fixture/pom3.xml";
+
+describe('require("pom-parser")', function () {
+
+  describe('loading invalid files', function() {
+    /**
+     * Per the xml spec (https://www.w3.org/TR/REC-xml/#sec-comments):
+     * "For compatibility, the string ' -- ' (double-hyphen) must not occur within comments"
+     * 
+     * The pom parser should return with an error response detailing why it failed. The parse() function does not return a promise 
+     * but rather a callback with error and response parameters. 
+     */
+    it('gracefully fails to parse invalid xml', function(done) {
+      pomParser.parse({filePath: POM_PATH}, function(err, response) {
+        // this looks weird, but it's for earlier ECMAScript versions
+        assert(err.message.lastIndexOf("Malformed comment", 0) === 0, "Invalid xml (with -- inside a comment) should return an error with 'Malformed comment'");
+	      done();
+      });
+    });
+  });
+});
+``


### PR DESCRIPTION
Issue #13 assumes that the parser returns a promise. The parse() function calls the passed in callback with an error and response params. This pull request contains a unit tests that demonstrates the graceful error/failure case for invalid xml (comment containing '--'). 

I would appreciate this case/pr being tagged with #hacktoberfest