### PR TITLE
Upgrade dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ build/Release
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
 npm-shrinkwrap.json
+.nyc_output/
+.idea/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 sudo: false
+dist: bionic
 language: node_js
 node_js:
-- '0.12'
-- '0.11'
-- '0.10'
-- iojs
+- '6'
+- '8'
+- '10'
+- '12'
+after_success: npm run coverage
 deploy:
   provider: npm
   email: marcello.desales@gmail.com

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,7 @@
 
 "use strict";
 
-var Promise = require("bluebird");
-var fs = Promise.promisifyAll(require("fs"));
+const fs = require("fs");
 var xml2js = require("xml2js");
 var traverse = require('traverse');
 
@@ -33,7 +32,7 @@ module.exports.parse = function(opt, callback) {
   // If the xml content is was not provided by the api client.
   // https://github.com/petkaantonov/bluebird/blob/master/API.md#error-rejectedhandler----promise
   if (!opt.xmlContent) {
-    fs.readFileAsync(opt.filePath, "utf8").then(function(xmlContent) {
+    readFileAsync(opt.filePath, "utf8").then(function(xmlContent) {
       return xmlContent;
 
     }).then(_parseWithXml2js).then(function(result) {
@@ -41,18 +40,15 @@ module.exports.parse = function(opt, callback) {
 
     }).catch(function(e) {
       callback(e, null);
- 
-    }).error(function (e) {
-      callback(e, null);
     });
 
   } else {
     // parse the xml provided by the api client.
     _parseWithXml2js(opt.xmlContent).then(function(result) {
-      delete result.xmlContent;  
+      delete result.xmlContent;
       callback(null, result);
 
-    }).error(function (e) {
+    }).catch(function (e) {
       callback(e);
     });
   }
@@ -98,4 +94,14 @@ function removeSingleArrays(obj) {
       this.update(value[0]);
     }
   });
+}
+
+function readFileAsync(path, encoding) {
+  return new Promise((resolve, reject) => fs.readFile(path, {encoding}, (err, data) => {
+    if (err) {
+      reject(err);
+    } else {
+      resolve(data);
+    }
+  }));
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "chai": "^3.0.0",
     "coveralls": "^3.0.8",
     "mocha": "^6.2.2",
-    "nyc": "^14.1.1",
-    "sinon": "^1.15.4"
+    "nyc": "^14.1.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "xml2js": "^0.4.9"
   },
   "devDependencies": {
-    "chai": "^3.0.0",
+    "chai": "^4.2.0",
     "coveralls": "^3.0.8",
     "mocha": "^6.2.2",
     "nyc": "^14.1.1"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "dependencies": {
-    "bluebird": "^2.9.34",
     "traverse": "^0.6.6",
     "xml2js": "^0.4.9"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "url": "https://about.me/marcellodesales"
   },
   "scripts": {
-    "test": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/.bin/codacy-coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+    "test": "nyc mocha",
+    "coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "dependencies": {
     "bluebird": "^2.9.34",
@@ -19,11 +20,9 @@
   },
   "devDependencies": {
     "chai": "^3.0.0",
-    "codacy-coverage": "^1.1.2",
-    "coveralls": "^2.11.3",
-    "istanbul": "^0.3.17",
-    "mocha": "^2.2.5",
-    "mocha-lcov-reporter": "0.0.2",
+    "coveralls": "^3.0.8",
+    "mocha": "^6.2.2",
+    "nyc": "^14.1.1",
     "sinon": "^1.15.4"
   },
   "repository": {


### PR DESCRIPTION
This is a second attempt at #14, broken into parts, and with the feedback incorporated.

 * update coverage setup according to current nyc (istanbul) and coveralls documentation
 * remove unused `sinon` dependency
 * upgrade other dev dependencies (no changes needed)
 * switch away from Bluebird to native promises, as node supports them now, and our needs are trivial.