### PR TITLE
Fix the  dependabot alert alert issue.

### DIFF
--- a/test/fixture/pom.xml
+++ b/test/fixture/pom.xml
@@ -15,7 +15,7 @@
 	<name>Tynamo Example - Federated Accounts</name>
 	
 	<properties>
-		<tapestry-release-version>5.3.1</tapestry-release-version>
+		<tapestry-release-version>5.8.2</tapestry-release-version>
 		<gae.version>1.3.0</gae.version>
 		<gae.home>${settings.localRepository}/com/google/appengine/appengine-api-1.0-sdk/${gae.version}/appengine-java-sdk-${gae.version}</gae.home>
 		<!-- Upload to http://0.latest.<applicationName>.appspot.com by default -->

--- a/test/fixture/pom2.xml
+++ b/test/fixture/pom2.xml
@@ -14,7 +14,7 @@
 	<name>Tynamo Example - Federated Accounts</name>
 	
 	<properties>
-		<tapestry-release-version>5.3.1</tapestry-release-version>
+		<tapestry-release-version>5.8.2</tapestry-release-version>
 		<gae.version>1.3.0</gae.version>
 		<gae.home>${settings.localRepository}/com/google/appengine/appengine-api-1.0-sdk/${gae.version}/appengine-java-sdk-${gae.version}</gae.home>
 		<!-- Upload to http://0.latest.<applicationName>.appspot.com by default -->


### PR DESCRIPTION
Issue:  [Issue#19](https://github.com/intuit/node-pom-parser/issues/19)

- Update the  **org.apache.tapestry**  to vulnerability free version which is 5.8.2 below 5.8.2 have vulnerability in dependency as we can see in maven repo https://mvnrepository.com/artifact/org.apache.tapestry/tapestry-core
- Update both the files pom.xml and pom2.xml